### PR TITLE
Set development release metadata

### DIFF
--- a/info.cemu.Cemu.yml
+++ b/info.cemu.Cemu.yml
@@ -199,7 +199,33 @@ modules:
             done
             Cemu_relwithdebinfo "$@"
         dest-filename: Cemu-wrapper
+      - type: script
+        dest-filename: dev_release_metainfo.py
+        commands:
+          - |
+            import os
+            import xml.etree.ElementTree as ET
+            meta_file = os.environ.get('AS_META_FILE')
+            version = os.environ.get('AS_META_VERSION')
+            release_type = os.environ.get('AS_META_TYPE')
+            release_date = os.environ.get('AS_META_DATE')
+            tree = ET.parse(meta_file)
+            root = tree.getroot()
+            el_releases = root.find('releases')
+            for el_release in el_releases:
+              el_releases.remove(el_release)
+            el_release = ET.SubElement(el_releases, 'release')
+            el_url = ET.SubElement(el_release, 'url')
+            el_url.text = f'https://github.com/cemu-project/Cemu/releases/tag/{version}'
+            el_release.attrib['type'] = release_type
+            el_release.attrib['date'] = release_date
+            el_release.attrib['version'] = version
+            ET.indent(tree, space="  ", level=0)
+            tree.write(meta_file, encoding='utf8')
     post-install:
+      - AS_META_DATE="$(git log -1 --format=%ci | awk '{print $1}')" AS_META_FILE='dist/linux/info.cemu.Cemu.metainfo.xml'
+        AS_META_TYPE='development' AS_META_VERSION="$(git describe --tags)" python
+        ./dev_release_metainfo.py
       - install -Dm644 -t ${FLATPAK_DEST}/share/appdata/ dist/linux/info.cemu.Cemu.metainfo.xml
       - install -Dm644 -t ${FLATPAK_DEST}/share/applications/ dist/linux/info.cemu.Cemu.desktop
       - install -Dm644 -t ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/ dist/linux/info.cemu.Cemu.png


### PR DESCRIPTION
Currently gnome-software lists Cemu as `2.0`.
`appstream-util modify` doesn't seem to be designed to modify the releases field.
A 20 line python bandage until Cemu on linux is stable.