### PR TITLE
Fix incorrect use of ~ tilde in AppStream versions

### DIFF
--- a/info.cemu.Cemu.yml
+++ b/info.cemu.Cemu.yml
@@ -227,7 +227,7 @@ modules:
       - AS_META_DATE="$(git log -1 --format=%ci | awk '{print $1}')" AS_META_FILE='dist/linux/info.cemu.Cemu.metainfo.xml'
         AS_META_URL="https://github.com/cemu-project/Cemu/releases/tag/$(git describe
         --tags)" AS_META_TYPE='development' AS_META_VERSION="$(git describe --tags
-        | tr -d 'v' | sed 's/-/~experimental/')" python ./dev_release_metainfo.py
+        | tr -d 'v')" python ./dev_release_metainfo.py
       - install -Dm644 -t ${FLATPAK_DEST}/share/appdata/ dist/linux/info.cemu.Cemu.metainfo.xml
       - install -Dm644 -t ${FLATPAK_DEST}/share/applications/ dist/linux/info.cemu.Cemu.desktop
       - install -Dm644 -t ${FLATPAK_DEST}/share/icons/hicolor/128x128/apps/ dist/linux/info.cemu.Cemu.png


### PR DESCRIPTION
This fixes 273db55, which adopted Cemu version tags as AppStream release versions, replacing the `-` character with `~`. That is incorrect use of the tilde, resulting in new releases that a version-respecting package manager will see as older than the previous version.

Observe:

    $ appstreamcli compare-versions  2.0 2.0~experimental34
    2.0 >> 2.0~experimental34
    $ appstreamcli compare-versions  2.0 2.0-experimental34
    2.0 << 2.0-experimental34

Correct use of `~` would be in prerelease versions, for ordering like this:

    2.0
    2.1~rc1
    2.1~rc2
    2.1

Since Cemu's version tags are already valid AppStream versions, we can simply use the tags as-is:

    $ appstreamcli compare-versions  2.0 2.0-34
    2.0 << 2.0-34

We don't need to insert the word "experimental" into the version number, since we already mark these experimental releases with `type="development"`.

https://www.freedesktop.org/software/appstream/docs/chap-AppStream-Misc.html#spec-vercmp-algorithm

https://www.freedesktop.org/software/appstream/docs/sect-Metadata-Releases.html