### PR TITLE
Add xdg-config permission to fix dark theme

### DIFF
--- a/info.cemu.Cemu.yml
+++ b/info.cemu.Cemu.yml
@@ -16,6 +16,7 @@ finish-args:
   - --filesystem=host:ro
   - --filesystem=xdg-run/app/com.discordapp.Discord:ro
   - --filesystem=xdg-run/app/com.discordapp.DiscordCanary:ro
+  - --filesystem=xdg-config/gtk-3.0:ro
 
 modules:
 # Required so we can use wxWidgets with openGL integration


### PR DESCRIPTION
This additional permission should resolve the broken theming on some systems.

Tested on my system:
Operating System: Arch Linux 
KDE Plasma Version: 5.27.7
KDE Frameworks Version: 5.108.0
Qt Version: 5.15.10
Kernel Version: 6.4.9-arch1-1 (64-bit)
Graphics Platform: Wayland

Fixes #17.