### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/info.cemu.Cemu.yml
+++ b/info.cemu.Cemu.yml
@@ -13,7 +13,12 @@ finish-args:
   - --share=ipc
   - --share=network
   - --env=LC_ALL=C
-  - --filesystem=host:ro
+  - --filesystem=home:ro
+  - --filesystem=/media:ro
+  - --filesystem=/mnt:ro
+  - --filesystem=/run/media:ro
+  - --filesystem=/var/run/media:ro
+  - --filesystem=/var/mnt:ro
   - --filesystem=xdg-run/app/com.discordapp.Discord:ro
   - --filesystem=xdg-run/app/com.discordapp.DiscordCanary:ro
   - --filesystem=xdg-config/gtk-3.0:ro


### PR DESCRIPTION
it should not have host access. Does it work without saving files?

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt