### PR TITLE
Fetch only required submodules as a workaround

### DIFF
--- a/info.cemu.Cemu.yml
+++ b/info.cemu.Cemu.yml
@@ -232,6 +232,7 @@ modules:
       - type: git
         url: https://github.com/Exzap/ZArchive
         dest: dependencies/ZArchive
+        tag: v0.1.2
       - type: git
         url: https://github.com/ocornut/imgui
         dest: dependencies/imgui

--- a/info.cemu.Cemu.yml
+++ b/info.cemu.Cemu.yml
@@ -224,6 +224,18 @@ modules:
           tag-pattern: ^v([\d.]+-\d+)$
         tag: v2.0-82
         commit: 7d6d4173549a55070683feac33afaad038383813
+        disable-submodules: true
+      - type: git
+        url: https://github.com/mozilla/cubeb
+        commit: 6c1a6e151c1f981a2800d40af7c041cfcccc710e
+        dest: dependencies/cubeb
+      - type: git
+        url: https://github.com/Exzap/ZArchive
+        dest: dependencies/ZArchive
+      - type: git
+        url: https://github.com/ocornut/imgui
+        dest: dependencies/imgui
+        commit: f65bcf481ab34cd07d3909aab1479f409fa79f2f
       - type: shell
         commands:
           - sed "s/set(EXPERIMENTAL_VERSION.*/set(EXPERIMENTAL_VERSION \"$(git describe


### PR DESCRIPTION
I believe the current build issue is due to [this curl issue](https://www.github.com/curl/curl/issues/13229).
At least looking up the error message `error: RPC failed; HTTP 400 curl 22 The requested URL returned error: 400` brought up a lot of reports of git clone failures in the recent weeks due to the linked issue.

Let's use this workaround for now and then revert it again in the future. Changes in this PR were tested locally and build successfully.