### PR TITLE
Flatpak: Grant access to Gamescope socket for Steam Deck

### DIFF
--- a/info.cemu.Cemu.yml
+++ b/info.cemu.Cemu.yml
@@ -17,6 +17,8 @@ finish-args:
   - --filesystem=home/.local/share/applications:create
   - --filesystem=xdg-run/app/com.discordapp.Discord:ro
   - --filesystem=xdg-run/app/com.discordapp.DiscordCanary:ro
+  # Required for Gamescope on Steam Deck OLED when using the Vulkan renderer
+  - --filesystem=xdg-run/gamescope-0:ro
 
 modules:
   - shared-modules/libusb/libusb.json


### PR DESCRIPTION
* See https://github.com/flathub/org.DolphinEmu.dolphin-emu/pull/178#issuecomment-1905194043 for more information
* Bug only occurs on the Steam Deck OLED when using the Vulkan renderer.

To replicate the error, on a Steam Deck OLED, install the Gamescope Flatpak, set renderer to Vulkan, launch a ROM in Game Mode through the Cemu GUI, see error. Gamescope Flatpak is primarily used for HDR in other Flatpaks (Dolphin, PrimeHack, Heroic, etc.).

![image](https://github.com/user-attachments/assets/745b9487-b8ed-4d3f-bb55-6e02c152ba92)